### PR TITLE
FormBuilder HtmlHelper not outputting classes for labels.

### DIFF
--- a/contentbox-formbuilder/plugins/HTMLHelper.cfc
+++ b/contentbox-formbuilder/plugins/HTMLHelper.cfc
@@ -618,7 +618,7 @@
 			// create label tag
 			if( len(arguments.label) ){
 				buffer.append("<" & arguments.label);
-				if( NOT len(arguments.labelclass) ){ buffer.append(' class="' & arguments.labelClass & '"'); }
+				if( len(arguments.labelclass) ){ buffer.append(' class="' & arguments.labelClass & '"'); }
 				flattenAttributes(arguments,"content,field,wrapper,label,labelclass",buffer).append(">#arguments.content#</" & arguments.label & ">");
 			}
 


### PR DESCRIPTION
An incorrect NOT in the conditional is preventing labelclass from being output (except when blank) in label function.
